### PR TITLE
Added openssl dependency and tagged build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM resin/rpi-raspbian:wheezy
 RUN apt-get update -q
-RUN apt-get install -qy openvpn iptables socat curl
+RUN apt-get install -qy openvpn iptables socat curl openssl
 ADD ./bin /usr/local/sbin
 VOLUME /etc/openvpn
 EXPOSE 443/tcp 1194/udp 8080/tcp

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Quick instructions:
 
 ```bash
 git clone https://github.com/dimetron/dockvpn-rpi.git
-docker build dockvpn-rpi
+docker build -t dockvpn-rpi dockvpn-rpi
 docker run -d --privileged  --name vpn --restart=always -p 1194:1194/udp -p 443:443/tcp --dns=8.8.8.8 dockvpn-rpi /bin/sh -c run
 sudo docker run -t -i -p 8080:8080 --dns=8.8.8.8 --rm  --volumes-from vpn dockvpn-rpi serveconfig
 ```


### PR DESCRIPTION
- Added `openssl` dependency or the first run step will just keep restarting.
- Tagged the build so that the image has a name.
